### PR TITLE
Feature/parse unknown tag

### DIFF
--- a/sources/include/citygml/attributesmap.h
+++ b/sources/include/citygml/attributesmap.h
@@ -22,7 +22,8 @@ enum class AttributeType
     Date,
     Uri,
     Measure,
-    AttributeSet
+    AttributeSet,
+    Boolean
 };
 
 /**

--- a/sources/include/parser/gmlobjectparser.h
+++ b/sources/include/parser/gmlobjectparser.h
@@ -14,6 +14,7 @@ namespace citygml {
     class GMLObjectElementParser : public CityGMLElementParser {
     public:
         GMLObjectElementParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger);
+        const AttributeType detectAttributeType(const std::string& characters);
 
     private:
         std::string m_lastCodeSpace;

--- a/sources/include/parser/gmlobjectparser.h
+++ b/sources/include/parser/gmlobjectparser.h
@@ -2,6 +2,7 @@
 
 #include <parser/citygmlelementparser.h>
 #include "citygml/attributesmap.h"
+#include <vector>
 
 namespace citygml {
 

--- a/sources/include/parser/gmlobjectparser.h
+++ b/sources/include/parser/gmlobjectparser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <parser/citygmlelementparser.h>
+#include "citygml/attributesmap.h"
 
 namespace citygml {
 
@@ -12,6 +13,10 @@ namespace citygml {
     class GMLObjectElementParser : public CityGMLElementParser {
     public:
         GMLObjectElementParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger);
+
+    private:
+        std::string m_lastCodeSpace;
+        std::shared_ptr<std::vector<AttributesMap>> m_attributeHierarchy;
 
     protected:
         // CityGMLElementParser interface

--- a/sources/include/parser/nodetypes.h
+++ b/sources/include/parser/nodetypes.h
@@ -26,6 +26,9 @@ namespace citygml {
             bool operator!=(const XMLNode& other) const;
 
             bool valid() const;
+
+            void set_name(const std::string& name);
+            void set_prefix(const std::string& name);
         private:
             std::string m_name;
             std::string m_prefix;

--- a/sources/include/parser/nodetypes.h
+++ b/sources/include/parser/nodetypes.h
@@ -27,8 +27,8 @@ namespace citygml {
 
             bool valid() const;
 
-            void set_name(const std::string& name);
-            void set_prefix(const std::string& name);
+            void setName(const std::string& name);
+            void setPrefix(const std::string& name);
         private:
             std::string m_name;
             std::string m_prefix;

--- a/sources/src/parser/citygmldocumentparser.cpp
+++ b/sources/src/parser/citygmldocumentparser.cpp
@@ -60,8 +60,8 @@ namespace citygml {
         if (!node.valid()) {
             size_t pos = name.find_first_of(":");
             if (pos != std::string::npos) {
-                node.set_name(name.substr(pos + 1));
-                node.set_prefix(name.substr(0, pos));
+                node.setName(name.substr(pos + 1));
+                node.setPrefix(name.substr(0, pos));
             }
         }
 
@@ -91,8 +91,8 @@ namespace citygml {
         if (!node.valid()) {
             size_t pos = name.find_first_of(":");
             if (pos != std::string::npos) {
-                node.set_name(name.substr(pos + 1));
-                node.set_prefix(name.substr(0, pos));
+                node.setName(name.substr(pos + 1));
+                node.setPrefix(name.substr(0, pos));
             }
         }
 

--- a/sources/src/parser/citygmldocumentparser.cpp
+++ b/sources/src/parser/citygmldocumentparser.cpp
@@ -55,12 +55,23 @@ namespace citygml {
             return;
         }
 
-        const NodeType::XMLNode& node = NodeType::getXMLNodeFor(name);
+        //const NodeType::XMLNode& node = NodeType::getXMLNodeFor(name);
+        NodeType::XMLNode node = NodeType::getXMLNodeFor(name);
 
+        /*
         if (!node.valid()) {
             CITYGML_LOG_WARN(m_logger, "Found start tag of unknown node <" << name << "> at " << getDocumentLocation() << ". Skip to next element.");
             skipUnknownOrUnexpectedElement(name);
             return;
+        }
+        */
+
+        if (!node.valid()) {
+            size_t pos = name.find_first_of(":");
+            if (pos != std::string::npos) {
+                node.set_name(name.substr(pos + 1));
+                node.set_prefix(name.substr(0, pos));
+            }
         }
 
         if (m_parserStack.empty()) {
@@ -84,11 +95,20 @@ namespace citygml {
             return;
         }
 
-        const NodeType::XMLNode& node = NodeType::getXMLNodeFor(name);
-
+        NodeType::XMLNode node = NodeType::getXMLNodeFor(name);
+        /*
         if (!node.valid()) {
             CITYGML_LOG_WARN(m_logger, "Found end tag of unknown node <" << name << "> at " << getDocumentLocation());
             return;
+        }
+        */
+
+        if (!node.valid()) {
+            size_t pos = name.find_first_of(":");
+            if (pos != std::string::npos) {
+                node.set_name(name.substr(pos + 1));
+                node.set_prefix(name.substr(0, pos));
+            }
         }
 
         if (m_parserStack.empty()) {

--- a/sources/src/parser/citygmldocumentparser.cpp
+++ b/sources/src/parser/citygmldocumentparser.cpp
@@ -55,16 +55,7 @@ namespace citygml {
             return;
         }
 
-        //const NodeType::XMLNode& node = NodeType::getXMLNodeFor(name);
         NodeType::XMLNode node = NodeType::getXMLNodeFor(name);
-
-        /*
-        if (!node.valid()) {
-            CITYGML_LOG_WARN(m_logger, "Found start tag of unknown node <" << name << "> at " << getDocumentLocation() << ". Skip to next element.");
-            skipUnknownOrUnexpectedElement(name);
-            return;
-        }
-        */
 
         if (!node.valid()) {
             size_t pos = name.find_first_of(":");
@@ -96,12 +87,6 @@ namespace citygml {
         }
 
         NodeType::XMLNode node = NodeType::getXMLNodeFor(name);
-        /*
-        if (!node.valid()) {
-            CITYGML_LOG_WARN(m_logger, "Found end tag of unknown node <" << name << "> at " << getDocumentLocation());
-            return;
-        }
-        */
 
         if (!node.valid()) {
             size_t pos = name.find_first_of(":");

--- a/sources/src/parser/gmlobjectparser.cpp
+++ b/sources/src/parser/gmlobjectparser.cpp
@@ -1,22 +1,26 @@
 #include "parser/gmlobjectparser.h"
 
 #include <citygml/object.h>
+#include "parser/attributes.h"
+#include <citygml/citygmlfactory.h>
+#include "parser/documentlocation.h"
+
+#include <iostream>
 
 namespace citygml {
 
     GMLObjectElementParser::GMLObjectElementParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger)
-        : CityGMLElementParser(documentParser, factory, logger)
-    {
-
+        : CityGMLElementParser(documentParser, factory, logger) {
+        m_lastCodeSpace = "";
+        m_attributeHierarchy = std::shared_ptr<std::vector<AttributesMap>>(new std::vector<AttributesMap>);
     }
 
-    bool GMLObjectElementParser::parseChildElementStartTag(const NodeType::XMLNode& node, Attributes& attributes)
-    {
+    bool GMLObjectElementParser::parseChildElementStartTag(const NodeType::XMLNode& node, Attributes& attributes) {
         if (getObject() == nullptr) {
             throw std::runtime_error("Invalid call to GMLObjectElementParser::parseChildElementStartTag");
         }
 
-        if (   node == NodeType::GML_DescriptionNode
+        if (node == NodeType::GML_DescriptionNode
             || node == NodeType::GML_IdentifierNode
             || node == NodeType::GML_NameNode
             || node == NodeType::GML_DescriptionReferenceNode
@@ -25,26 +29,85 @@ namespace citygml {
             return true;
         }
 
-        return false;
+        size_t pos = node.name().find_first_of(":");
+        if (pos != std::string::npos) {
+            if (isupper(node.name().substr(pos + 1).at(0))) {// Ignore Tag start with capital letter
+                return true;
+            }
+        }
+
+        //std::cout << "Tag " << node.name() << " Started!" << std::endl;
+        AttributesMap attributeSet;
+        m_attributeHierarchy->push_back(attributeSet);
+
+        m_lastCodeSpace = attributes.getAttribute("codeSpace");
+
+        return true;
     }
 
-    bool GMLObjectElementParser::parseChildElementEndTag(const NodeType::XMLNode& node, const std::string& characters)
-    {
+    bool GMLObjectElementParser::parseChildElementEndTag(const NodeType::XMLNode& node, const std::string& characters) {
         if (getObject() == nullptr) {
             throw std::runtime_error("Invalid call to GMLObjectElementParser::parseChildElementEndTag");
         }
 
-        if (   node == NodeType::GML_DescriptionNode
+        if (node == NodeType::GML_DescriptionNode
             || node == NodeType::GML_IdentifierNode
             || node == NodeType::GML_NameNode
             || node == NodeType::GML_DescriptionReferenceNode
             || node == NodeType::GML_MetaDataPropertyNode) {
 
-                getObject()->setAttribute(node.name(), characters);
-                return true;
+            getObject()->setAttribute(node.name(), characters);
+            return true;
         }
 
-        return false;
+        size_t pos = node.name().find_first_of(":");
+        if (pos != std::string::npos) {
+            if (isupper(node.name().substr(pos + 1).at(0))) {// Ignore Tag start with capital letter
+                return true;
+            }
+        }
+
+        //std::cout << "Tag " << node.name() << " Ended!" << std::endl;
+
+        auto& attributesMap = m_attributeHierarchy->back();
+
+        if (m_attributeHierarchy->size() == 1) { // no parent tag
+            if (attributesMap.size() == 0) { // no child tag
+                if (m_lastCodeSpace == "") {
+                    getObject()->setAttribute(node.name(), characters);
+                    //std::cout << "getObject()->setAttribute(" << node.name() << ", " << characters << "); " << std::endl;
+                } else {
+                    const auto codeValue = m_factory.getCodeValue(m_lastCodeSpace, getDocumentLocation().getDocumentFileName(), characters);
+                    getObject()->setAttribute(node.name(), codeValue);
+                    //std::cout << "getObject()->setAttribute(" << node.name() << ", " << codeValue << "); " << std::endl;
+                }
+            } else { // have child tag
+                getObject()->getAttributes()[node.name()] = attributesMap;
+                //std::cout << "getObject()->getAttributes()[" << node.name() << "] = attributesMap; " << std::endl;
+            }
+            m_attributeHierarchy->pop_back();
+        } else { // have parent tag
+            if (attributesMap.size() == 0) { // no child tag
+                m_attributeHierarchy->pop_back();
+                auto& parent_attributesMap = m_attributeHierarchy->back();
+                if (m_lastCodeSpace == "") {
+                    parent_attributesMap[node.name()] = characters;
+                    //std::cout << "parent_attributesMap[" << node.name() << "] = " << characters << "; " << std::endl;
+                } else {
+                    const auto codeValue = m_factory.getCodeValue(m_lastCodeSpace, getDocumentLocation().getDocumentFileName(), characters);
+                    parent_attributesMap[node.name()] = codeValue;
+                    //std::cout << "parent_attributesMap[" << node.name() << "] = " << codeValue << "; " << std::endl;
+                }
+            } else { // have child tag
+                auto my_attributesMap = attributesMap;
+                m_attributeHierarchy->pop_back();
+                auto& parent_attributesMap = m_attributeHierarchy->back();
+                parent_attributesMap[node.name()] = my_attributesMap;
+                //std::cout << "parent_attributesMap[" << node.name() << "] = my_attributesMap; " << std::endl;
+            }
+        }
+        
+        return true;
     }
 
 }

--- a/sources/src/parser/gmlobjectparser.cpp
+++ b/sources/src/parser/gmlobjectparser.cpp
@@ -36,7 +36,6 @@ namespace citygml {
             }
         }
 
-        //std::cout << "Tag " << node.name() << " Started!" << std::endl;
         AttributesMap attributeSet;
         m_attributeHierarchy->push_back(attributeSet);
 
@@ -67,23 +66,18 @@ namespace citygml {
             }
         }
 
-        //std::cout << "Tag " << node.name() << " Ended!" << std::endl;
-
         auto& attributesMap = m_attributeHierarchy->back();
 
         if (m_attributeHierarchy->size() == 1) { // no parent tag
             if (attributesMap.size() == 0) { // no child tag
                 if (m_lastCodeSpace == "") {
                     getObject()->setAttribute(node.name(), characters);
-                    //std::cout << "getObject()->setAttribute(" << node.name() << ", " << characters << "); " << std::endl;
                 } else {
                     const auto codeValue = m_factory.getCodeValue(m_lastCodeSpace, getDocumentLocation().getDocumentFileName(), characters);
                     getObject()->setAttribute(node.name(), codeValue);
-                    //std::cout << "getObject()->setAttribute(" << node.name() << ", " << codeValue << "); " << std::endl;
                 }
             } else { // have child tag
                 getObject()->getAttributes()[node.name()] = attributesMap;
-                //std::cout << "getObject()->getAttributes()[" << node.name() << "] = attributesMap; " << std::endl;
             }
             m_attributeHierarchy->pop_back();
         } else { // have parent tag
@@ -92,18 +86,15 @@ namespace citygml {
                 auto& parent_attributesMap = m_attributeHierarchy->back();
                 if (m_lastCodeSpace == "") {
                     parent_attributesMap[node.name()] = characters;
-                    //std::cout << "parent_attributesMap[" << node.name() << "] = " << characters << "; " << std::endl;
                 } else {
                     const auto codeValue = m_factory.getCodeValue(m_lastCodeSpace, getDocumentLocation().getDocumentFileName(), characters);
                     parent_attributesMap[node.name()] = codeValue;
-                    //std::cout << "parent_attributesMap[" << node.name() << "] = " << codeValue << "; " << std::endl;
                 }
             } else { // have child tag
                 auto my_attributesMap = attributesMap;
                 m_attributeHierarchy->pop_back();
                 auto& parent_attributesMap = m_attributeHierarchy->back();
                 parent_attributesMap[node.name()] = my_attributesMap;
-                //std::cout << "parent_attributesMap[" << node.name() << "] = my_attributesMap; " << std::endl;
             }
         }
         

--- a/sources/src/parser/gmlobjectparser.cpp
+++ b/sources/src/parser/gmlobjectparser.cpp
@@ -4,15 +4,16 @@
 #include "parser/attributes.h"
 #include <citygml/citygmlfactory.h>
 #include "parser/documentlocation.h"
-
+#include <regex>
 #include <iostream>
 
 namespace citygml {
 
     GMLObjectElementParser::GMLObjectElementParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger)
-        : CityGMLElementParser(documentParser, factory, logger) {
-        m_lastCodeSpace = "";
-        m_attributeHierarchy = std::shared_ptr<std::vector<AttributesMap>>(new std::vector<AttributesMap>);
+        : CityGMLElementParser(documentParser, factory, logger),
+        m_lastCodeSpace(""),
+        m_attributeHierarchy(std::make_shared<std::vector<AttributesMap>>()) {
+
     }
 
     bool GMLObjectElementParser::parseChildElementStartTag(const NodeType::XMLNode& node, Attributes& attributes) {
@@ -71,10 +72,10 @@ namespace citygml {
         if (m_attributeHierarchy->size() == 1) { // no parent tag
             if (attributesMap.size() == 0) { // no child tag
                 if (m_lastCodeSpace == "") {
-                    getObject()->setAttribute(node.name(), characters);
+                    getObject()->setAttribute(node.name(), characters, detectAttributeType(characters));
                 } else {
                     const auto codeValue = m_factory.getCodeValue(m_lastCodeSpace, getDocumentLocation().getDocumentFileName(), characters);
-                    getObject()->setAttribute(node.name(), codeValue);
+                    getObject()->setAttribute(node.name(), codeValue, detectAttributeType(codeValue));
                 }
             } else { // have child tag
                 getObject()->getAttributes()[node.name()] = attributesMap;
@@ -85,10 +86,10 @@ namespace citygml {
                 m_attributeHierarchy->pop_back();
                 auto& parent_attributesMap = m_attributeHierarchy->back();
                 if (m_lastCodeSpace == "") {
-                    parent_attributesMap[node.name()] = characters;
+                    parent_attributesMap[node.name()] = AttributeValue(characters, detectAttributeType(characters));
                 } else {
                     const auto codeValue = m_factory.getCodeValue(m_lastCodeSpace, getDocumentLocation().getDocumentFileName(), characters);
-                    parent_attributesMap[node.name()] = codeValue;
+                    parent_attributesMap[node.name()] = AttributeValue(codeValue, detectAttributeType(codeValue));
                 }
             } else { // have child tag
                 auto my_attributesMap = attributesMap;
@@ -101,4 +102,27 @@ namespace citygml {
         return true;
     }
 
+    const AttributeType GMLObjectElementParser::detectAttributeType(const std::string& characters) {
+        if (characters == "true" || characters == "false") {
+            return AttributeType::Boolean;
+        }
+        std::regex re_int(R"([0-9]+)");
+        if (std::regex_match(characters, re_int)) {
+            return AttributeType::Integer;
+        }
+        std::regex re_double(R"([0-9]+\.[0-9]*)");
+        if (std::regex_match(characters, re_double)) {
+            return AttributeType::Double;
+        }
+        std::regex re_date(R"(\d{4}-\d\d-\d\d)");
+        if (std::regex_match(characters, re_date)) {
+            return AttributeType::Date;
+        }
+        std::regex re_uri(R"(http.*)");
+        if (std::regex_match(characters, re_uri)) {
+            return AttributeType::Uri;
+        }
+
+        return AttributeType::String;
+    }
 }

--- a/sources/src/parser/nodetypes.cpp
+++ b/sources/src/parser/nodetypes.cpp
@@ -66,6 +66,14 @@ namespace citygml {
         return os;
     }
 
+    void NodeType::XMLNode::set_name(const std::string& name) {
+        m_name = name;
+    }
+
+    void NodeType::XMLNode::set_prefix(const std::string& prefix) {
+        m_prefix = prefix;
+    }
+
     const NodeType::XMLNode NodeType::InvalidNode = XMLNode("", "");
 
 #define INITIALIZE_NODE( prefix, elementname ) \

--- a/sources/src/parser/nodetypes.cpp
+++ b/sources/src/parser/nodetypes.cpp
@@ -457,23 +457,7 @@ namespace citygml {
             }
         }
 
-        std::string nodeName = lowerName;
-
-        size_t pos = nodeName.find_first_of( ":" );
-        if ( pos != std::string::npos ) {
-            nodeName = nodeName.substr(pos + 1);
-        } else {
-            // node has no prefix... try with core prefix
-            return getXMLNodeFor("core:" + name);
-        }
-
-        auto it = nodeNameTypeMap.find(nodeName);
-
-        if (it == nodeNameTypeMap.end()) {
-            return InvalidNode;
-        } else {
-            return *it->second;
-        }
+        return InvalidNode;
     }
 
 #define DEFINE_NODE( prefix, elementname ) NodeType::XMLNode NodeType::prefix ## _ ## elementname ## Node;

--- a/sources/src/parser/nodetypes.cpp
+++ b/sources/src/parser/nodetypes.cpp
@@ -66,11 +66,11 @@ namespace citygml {
         return os;
     }
 
-    void NodeType::XMLNode::set_name(const std::string& name) {
+    void NodeType::XMLNode::setName(const std::string& name) {
         m_name = name;
     }
 
-    void NodeType::XMLNode::set_prefix(const std::string& prefix) {
+    void NodeType::XMLNode::setPrefix(const std::string& prefix) {
         m_prefix = prefix;
     }
 


### PR DESCRIPTION
未知のタグが来た際に既存の地物型への属性として追加する（タグ名をキー、中身を値としてAttributesに全部詰め込む）。
属性にcodeSpaceを含む要素の場合はcodeSpaceのパース結果を値とする。
その際、タグの階層構造は維持するようにする。
ただし、大文字スタートのタグは無視する。

