### PR TITLE
parse ADE objects

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -91,6 +91,7 @@ SET(SOURCES
   src/parser/elementparser.cpp
 
   src/parser/delayedchoiceelementparser.cpp
+  src/parser/unknownelementparser.cpp
   src/parser/skipelementparser.cpp
   src/parser/sequenceparser.cpp
 
@@ -177,6 +178,7 @@ SET(HEADERS
   include/parser/elementparser.h
 
   include/parser/delayedchoiceelementparser.h
+  include/parser/unknownelementparser.h
   include/parser/skipelementparser.h
   include/parser/sequenceparser.h
 

--- a/sources/include/citygml/cityobject.h
+++ b/sources/include/citygml/cityobject.h
@@ -73,6 +73,8 @@ namespace citygml {
            	// ADD Buildding model 
 			COT_IntBuildingInstallation		= 1ll<< 34,
 
+            COT_Unknown                     = 1ll<< 40,
+
             COT_All                         = 0xFFFFFFFFFFFFFFFFull
         };
 

--- a/sources/include/parser/cityobjectelementparser.h
+++ b/sources/include/parser/cityobjectelementparser.h
@@ -18,6 +18,8 @@ namespace citygml {
         // ElementParser interface
         virtual std::string elementParserName() const override;
         virtual bool handlesElement(const NodeType::XMLNode &node) const override;
+        void SetUnknownCityObjectComingFlg(bool flg);
+
     protected:
 
         // CityGMLElementParser interface
@@ -58,6 +60,8 @@ namespace citygml {
 
         std::string m_lastCodeSpace;
         std::string m_lastCode;
+
+        bool m_unknownCityObjectCommingFlg;
     };
 
 }

--- a/sources/include/parser/cityobjectelementparser.h
+++ b/sources/include/parser/cityobjectelementparser.h
@@ -18,7 +18,6 @@ namespace citygml {
         // ElementParser interface
         virtual std::string elementParserName() const override;
         virtual bool handlesElement(const NodeType::XMLNode &node) const override;
-        void SetUnknownCityObjectComingFlg(bool flg);
 
     protected:
 
@@ -61,7 +60,6 @@ namespace citygml {
         std::string m_lastCodeSpace;
         std::string m_lastCode;
 
-        bool m_unknownCityObjectCommingFlg;
     };
 
 }

--- a/sources/include/parser/delayedchoiceelementparser.h
+++ b/sources/include/parser/delayedchoiceelementparser.h
@@ -30,13 +30,8 @@ namespace citygml {
         virtual bool handlesElement(const NodeType::XMLNode& node) const;
         virtual std::string elementParserName() const;
 
-        void setUnknownNodeFlg(bool flg);
-        void setStockNode(const NodeType::XMLNode& node);
-
     private:
         std::vector<ElementParser*> m_choices;
-        bool m_unknownNodeFlg;
-        NodeType::XMLNode m_stockNode;
     };
 
 }

--- a/sources/include/parser/delayedchoiceelementparser.h
+++ b/sources/include/parser/delayedchoiceelementparser.h
@@ -30,8 +30,13 @@ namespace citygml {
         virtual bool handlesElement(const NodeType::XMLNode& node) const;
         virtual std::string elementParserName() const;
 
+        void setUnknownNodeFlg(bool flg);
+        void setStockNode(const NodeType::XMLNode& node);
+
     private:
         std::vector<ElementParser*> m_choices;
+        bool m_unknownNodeFlg;
+        NodeType::XMLNode m_stockNode;
     };
 
 }

--- a/sources/include/parser/geometryelementparser.h
+++ b/sources/include/parser/geometryelementparser.h
@@ -18,6 +18,8 @@ namespace citygml {
         // ElementParser interface
         virtual std::string elementParserName() const override;
         virtual bool handlesElement(const NodeType::XMLNode &node) const override;
+        void SetUnknownGeometryComingFlg(bool flg);
+
     protected:
         // CityGMLElementParser interface
         virtual bool parseElementStartTag(const NodeType::XMLNode& node, Attributes& attributes) override;
@@ -34,6 +36,7 @@ namespace citygml {
         int m_lodLevel;
         CityObject::CityObjectsType m_parentType;
         std::string m_orientation;
+        bool m_unknownGeometryCommingFlg;
     };
 
 }

--- a/sources/include/parser/geometryelementparser.h
+++ b/sources/include/parser/geometryelementparser.h
@@ -18,7 +18,6 @@ namespace citygml {
         // ElementParser interface
         virtual std::string elementParserName() const override;
         virtual bool handlesElement(const NodeType::XMLNode &node) const override;
-        void SetUnknownGeometryComingFlg(bool flg);
 
     protected:
         // CityGMLElementParser interface
@@ -36,7 +35,6 @@ namespace citygml {
         int m_lodLevel;
         CityObject::CityObjectsType m_parentType;
         std::string m_orientation;
-        bool m_unknownGeometryCommingFlg;
     };
 
 }

--- a/sources/include/parser/gmlobjectparser.h
+++ b/sources/include/parser/gmlobjectparser.h
@@ -15,10 +15,14 @@ namespace citygml {
     public:
         GMLObjectElementParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger);
         const AttributeType detectAttributeType(const std::string& characters);
+        void setAdeDataComingFlg(bool flg);
+        bool getAdeDataComingFlg();
+        bool parseChildElementBothTag(const NodeType::XMLNode& node, const std::string& characters);
 
     private:
         std::string m_lastCodeSpace;
         std::shared_ptr<std::vector<AttributesMap>> m_attributeHierarchy;
+        bool m_adeDataComingFlg;
 
     protected:
         // CityGMLElementParser interface

--- a/sources/include/parser/gmlobjectparser.h
+++ b/sources/include/parser/gmlobjectparser.h
@@ -18,11 +18,13 @@ namespace citygml {
         void setAdeDataComingFlg(bool flg);
         bool getAdeDataComingFlg();
         bool parseChildElementBothTag(const NodeType::XMLNode& node, const std::string& characters);
+        void setSkippedTag(std::string tag_name);
 
     private:
         std::string m_lastCodeSpace;
         std::shared_ptr<std::vector<AttributesMap>> m_attributeHierarchy;
         bool m_adeDataComingFlg;
+        std::shared_ptr<std::vector<std::string>> m_skipped_tag;
 
     protected:
         // CityGMLElementParser interface

--- a/sources/include/parser/unknownelementparser.h
+++ b/sources/include/parser/unknownelementparser.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include "parser/elementparser.h"
+
+namespace citygml {
+
+    /**
+     * @brief The UnknownElementParser allows to parse xml elements of which the concrete type is not known in advance
+     *
+     * The UnknownElementParser is initialized with a list of possible parses. When the start element of the next node is parsed it chooses the
+     * first parser that can handle the element.
+     */
+    class UnknownElementParser : public ElementParser {
+    public:
+
+        /**
+         * @brief creates a UnknownElementParser
+         * @param documentParser
+         * @param logger
+         * @param choices the parsers to choose from. The UnknownElementParser takes ownership of the parsers.
+         */
+        UnknownElementParser(CityGMLDocumentParser& documentParser, std::shared_ptr<CityGMLLogger> logger, std::vector<ElementParser*> choices);
+
+        // ElementParser interface
+        virtual bool startElement(const NodeType::XMLNode& node, Attributes& attributes);
+        virtual bool endElement(const NodeType::XMLNode& node, const std::string& characters);
+        virtual bool handlesElement(const NodeType::XMLNode& node) const;
+        virtual std::string elementParserName() const;
+
+        void setStockNode(const NodeType::XMLNode& node);
+
+    private:
+        std::vector<ElementParser*> m_choices;
+        NodeType::XMLNode m_stockNode;
+    };
+
+}

--- a/sources/src/parser/citygmlelementparser.cpp
+++ b/sources/src/parser/citygmlelementparser.cpp
@@ -41,7 +41,7 @@ namespace citygml {
             throw std::runtime_error("CityGMLElementParser::endElement called on unbound CityGMLElementParser object.");
         }
 
-        if (m_boundElement == node) {
+        if (m_boundElement.prefix() == node.prefix() && m_boundElement.name() == node.name()) {// for InvalidNode also
             m_documentParser.removeCurrentElementParser(this);
             return parseElementEndTag(node, characters);
         } else {

--- a/sources/src/parser/cityobjectelementparser.cpp
+++ b/sources/src/parser/cityobjectelementparser.cpp
@@ -8,6 +8,7 @@
 #include "parser/polygonelementparser.h"
 #include "parser/skipelementparser.h"
 #include "parser/delayedchoiceelementparser.h"
+#include "parser/unknownelementparser.h"
 #include "parser/linestringelementparser.h"
 #include "parser/addressparser.h"
 #include "parser/rectifiedgridcoverageparser.h"
@@ -247,6 +248,7 @@ namespace citygml {
         if (m_unknownCityObjectCommingFlg) {
             m_unknownCityObjectCommingFlg = false;
             m_model = m_factory.createCityObject(attributes.getCityGMLIDAttribute(), CityObject::CityObjectsType::COT_Unknown);
+            m_model->setAttribute(node.name(), attributes.getCityGMLIDAttribute());
             return true;
         } else {
             if (it == typeIDTypeMap.end()) {
@@ -468,13 +470,12 @@ namespace citygml {
             } else if (attributes.getAttribute("codeSpace") != "") {
                 return GMLFeatureCollectionElementParser::parseChildElementStartTag(node, attributes);
             } else {
-                DelayedChoiceElementParser* dcep = new DelayedChoiceElementParser(m_documentParser, m_logger, {
+                UnknownElementParser* dcep = new UnknownElementParser(m_documentParser, m_logger, {
                     new GeometryElementParser(m_documentParser, m_factory, m_logger, 2, m_model->getType(), [this](Geometry* geom) { m_model->addGeometry(geom); }),
                     new CityObjectElementParser(m_documentParser, m_factory, m_logger, [this](CityObject* obj) { m_model->addChildCityObject(obj); }),
                     this
                     });
                 dcep->setStockNode(node);
-                dcep->setUnknownNodeFlg(true);
                 setParserForNextElement(dcep);
             }
         }else{

--- a/sources/src/parser/cityobjectelementparser.cpp
+++ b/sources/src/parser/cityobjectelementparser.cpp
@@ -45,6 +45,7 @@ namespace citygml {
         , m_lastCodeSpace("")
         , m_lastCode("")
         , m_lastAttributeName("")
+        , m_unknownCityObjectCommingFlg(false)
     {
         m_callback = callback;
     }
@@ -243,14 +244,18 @@ namespace citygml {
 
         auto it = typeIDTypeMap.find(node.typeID());
 
-        if (it == typeIDTypeMap.end()) {
-            CITYGML_LOG_ERROR(m_logger, "Expected start tag of CityObject but got <" << node.name() << "> at " << getDocumentLocation());
-            throw std::runtime_error("Unexpected start tag found.");
+        if (m_unknownCityObjectCommingFlg) {
+            m_unknownCityObjectCommingFlg = false;
+            m_model = m_factory.createCityObject(attributes.getCityGMLIDAttribute(), CityObject::CityObjectsType::COT_Unknown);
+            return true;
+        } else {
+            if (it == typeIDTypeMap.end()) {
+                CITYGML_LOG_ERROR(m_logger, "Expected start tag of CityObject but got <" << node.name() << "> at " << getDocumentLocation());
+                throw std::runtime_error("Unexpected start tag found.");
+            }
+            m_model = m_factory.createCityObject(attributes.getCityGMLIDAttribute(), static_cast<CityObject::CityObjectsType>(it->second));
+            return true;
         }
-
-        m_model = m_factory.createCityObject(attributes.getCityGMLIDAttribute(), static_cast<CityObject::CityObjectsType>(it->second));
-        return true;
-
     }
 
     bool CityObjectElementParser::parseElementEndTag(const NodeType::XMLNode&, const std::string&)
@@ -457,7 +462,22 @@ namespace citygml {
             m_lastCodeSpace = attributes.getAttribute("codeSpace");
         } else if (node == NodeType::URO_CodeValueNode ) {
             m_lastCode =  attributes.getAttribute("codeSpace");
-        } else {
+        } else if(node == NodeType::InvalidNode) {
+            if (getAdeDataComingFlg()) {
+                return GMLFeatureCollectionElementParser::parseChildElementStartTag(node, attributes);
+            } else if (attributes.getAttribute("codeSpace") != "") {
+                return GMLFeatureCollectionElementParser::parseChildElementStartTag(node, attributes);
+            } else {
+                DelayedChoiceElementParser* dcep = new DelayedChoiceElementParser(m_documentParser, m_logger, {
+                    new GeometryElementParser(m_documentParser, m_factory, m_logger, 2, m_model->getType(), [this](Geometry* geom) { m_model->addGeometry(geom); }),
+                    new CityObjectElementParser(m_documentParser, m_factory, m_logger, [this](CityObject* obj) { m_model->addChildCityObject(obj); }),
+                    this
+                    });
+                dcep->setStockNode(node);
+                dcep->setUnknownNodeFlg(true);
+                setParserForNextElement(dcep);
+            }
+        }else{
             return GMLFeatureCollectionElementParser::parseChildElementStartTag(node, attributes);
         }
 
@@ -622,6 +642,8 @@ namespace citygml {
             m_model->setAttribute(m_lastAttributeName, attributeValue);
 
             return true;
+        } else if (node == NodeType::InvalidNode) {
+            return GMLFeatureCollectionElementParser::parseChildElementEndTag(node, characters);
         }
 
         return GMLFeatureCollectionElementParser::parseChildElementEndTag(node, characters);
@@ -677,6 +699,10 @@ namespace citygml {
                                                                    })
         }));
 
+    }
+
+    void CityObjectElementParser::SetUnknownCityObjectComingFlg(bool flg) {
+        m_unknownCityObjectCommingFlg = flg;
     }
 
 }

--- a/sources/src/parser/cityobjectelementparser.cpp
+++ b/sources/src/parser/cityobjectelementparser.cpp
@@ -46,7 +46,6 @@ namespace citygml {
         , m_lastCodeSpace("")
         , m_lastCode("")
         , m_lastAttributeName("")
-        , m_unknownCityObjectCommingFlg(false)
     {
         m_callback = callback;
     }
@@ -244,20 +243,14 @@ namespace citygml {
         initializeTypeIDTypeMap();
 
         auto it = typeIDTypeMap.find(node.typeID());
-
-        if (m_unknownCityObjectCommingFlg) {
-            m_unknownCityObjectCommingFlg = false;
+       
+        if (it == typeIDTypeMap.end()) {
             m_model = m_factory.createCityObject(attributes.getCityGMLIDAttribute(), CityObject::CityObjectsType::COT_Unknown);
-            m_model->setAttribute(node.name(), attributes.getCityGMLIDAttribute());
-            return true;
         } else {
-            if (it == typeIDTypeMap.end()) {
-                CITYGML_LOG_ERROR(m_logger, "Expected start tag of CityObject but got <" << node.name() << "> at " << getDocumentLocation());
-                throw std::runtime_error("Unexpected start tag found.");
-            }
             m_model = m_factory.createCityObject(attributes.getCityGMLIDAttribute(), static_cast<CityObject::CityObjectsType>(it->second));
-            return true;
         }
+        return true;
+        
     }
 
     bool CityObjectElementParser::parseElementEndTag(const NodeType::XMLNode&, const std::string&)
@@ -700,10 +693,6 @@ namespace citygml {
                                                                    })
         }));
 
-    }
-
-    void CityObjectElementParser::SetUnknownCityObjectComingFlg(bool flg) {
-        m_unknownCityObjectCommingFlg = flg;
     }
 
 }

--- a/sources/src/parser/delayedchoiceelementparser.cpp
+++ b/sources/src/parser/delayedchoiceelementparser.cpp
@@ -1,9 +1,7 @@
 #include "parser/delayedchoiceelementparser.h"
-#include "parser/geometryelementparser.h"
+
 #include "parser/documentlocation.h"
 #include "parser/citygmldocumentparser.h"
-#include "parser/attributes.h"
-#include "parser/cityobjectelementparser.h"
 
 #include <citygml/citygmllogger.h>
 
@@ -14,69 +12,36 @@ namespace citygml {
 
     DelayedChoiceElementParser::DelayedChoiceElementParser(CityGMLDocumentParser& documentParser, std::shared_ptr<CityGMLLogger> logger, std::vector<ElementParser*> choices)
         : ElementParser(documentParser, logger)
-        , m_unknownNodeFlg(false)
-        , m_stockNode()
     {
         m_choices = choices;
     }
 
     bool DelayedChoiceElementParser::startElement(const NodeType::XMLNode& node, Attributes& attributes)
     {
-        if (m_unknownNodeFlg) {
-            m_unknownNodeFlg = false;
+        ElementParser* choosenParser = nullptr;
+        for (ElementParser* parser : m_choices) {
+
+            if (choosenParser == nullptr && parser->handlesElement(node)) {
+                choosenParser = parser;
+            } else {
+                delete parser;
+            }
+
+        }
+
+        if (choosenParser != nullptr) {
             m_documentParser.removeCurrentElementParser(this);
-            if (attributes.getAttribute("gml:id") == "") {
-                dynamic_cast <CityObjectElementParser*>(m_choices[2])->setAdeDataComingFlg(true);
-                m_choices[2]->startElement(m_stockNode, attributes);// for parent node
-                return m_choices[2]->startElement(node, attributes);
-            } else {
-                if(m_choices[0]->handlesElement(node)){// check for GeometryElementParser
-                    m_documentParser.setCurrentElementParser(m_choices[0]); // set GeometryElementParser
-                    delete m_choices[1];
-                    dynamic_cast <GeometryElementParser*>(m_choices[0])->SetUnknownGeometryComingFlg(true);
-                    m_choices[0]->startElement(m_stockNode, attributes);
-                    return m_choices[0]->startElement(node, attributes);
-                } else {
-                    m_documentParser.setCurrentElementParser(m_choices[1]);// set CityObjectElementParser
-                    delete m_choices[0];
-                    dynamic_cast <CityObjectElementParser*>(m_choices[1])->SetUnknownCityObjectComingFlg(true);
-                    m_choices[1]->startElement(m_stockNode, attributes);
-                    return m_choices[1]->startElement(node, attributes);
-                }
-            }
+            m_documentParser.setCurrentElementParser(choosenParser);
+            return choosenParser->startElement(node, attributes);
         } else {
-            ElementParser* choosenParser = nullptr;
-            for (ElementParser* parser : m_choices) {
-
-                if (choosenParser == nullptr && parser->handlesElement(node)) {
-                    choosenParser = parser;
-                } else {
-                    delete parser;
-                }
-            }
-
-            if (choosenParser != nullptr) {
-                m_documentParser.removeCurrentElementParser(this);
-                m_documentParser.setCurrentElementParser(choosenParser);
-                return choosenParser->startElement(node, attributes);
-            } else {
-                CITYGML_LOG_ERROR(m_logger, "DelayedChoiceElementParser could not find a parser to handle <" << node << "> at " << getDocumentLocation());
-                throw std::runtime_error("No parser for XML element found.");
-            }
+            CITYGML_LOG_ERROR(m_logger, "DelayedChoiceElementParser could not find a parser to handle <" << node << "> at " << getDocumentLocation());
+            throw std::runtime_error("No parser for XML element found.");
         }
     }
 
-    bool DelayedChoiceElementParser::endElement(const NodeType::XMLNode& node, const std::string& characters)
+    bool DelayedChoiceElementParser::endElement(const NodeType::XMLNode&, const std::string&)
     {
-        if (m_unknownNodeFlg) {// for unknown node which does not have any child
-            m_unknownNodeFlg = false;
-            m_documentParser.removeCurrentElementParser(this);
-            delete m_choices[0];
-            delete m_choices[1];
-            return dynamic_cast <CityObjectElementParser*>(m_choices[2])->parseChildElementBothTag(node, characters);
-        }else{
-            throw std::runtime_error("DelayedChoiceElementParser::endElement must never be called.");
-        }
+        throw std::runtime_error("DelayedChoiceElementParser::endElement must never be called.");
     }
 
     bool DelayedChoiceElementParser::handlesElement(const NodeType::XMLNode& node) const
@@ -104,14 +69,6 @@ namespace citygml {
 
         ss << ")";
         return ss.str();
-    }
-
-    void DelayedChoiceElementParser::setUnknownNodeFlg(bool flg) {
-        m_unknownNodeFlg = flg;
-    }
-
-    void DelayedChoiceElementParser::setStockNode(const NodeType::XMLNode& node) {
-        m_stockNode = node;
     }
 
 }

--- a/sources/src/parser/delayedchoiceelementparser.cpp
+++ b/sources/src/parser/delayedchoiceelementparser.cpp
@@ -1,7 +1,9 @@
 #include "parser/delayedchoiceelementparser.h"
-
+#include "parser/geometryelementparser.h"
 #include "parser/documentlocation.h"
 #include "parser/citygmldocumentparser.h"
+#include "parser/attributes.h"
+#include "parser/cityobjectelementparser.h"
 
 #include <citygml/citygmllogger.h>
 
@@ -12,36 +14,69 @@ namespace citygml {
 
     DelayedChoiceElementParser::DelayedChoiceElementParser(CityGMLDocumentParser& documentParser, std::shared_ptr<CityGMLLogger> logger, std::vector<ElementParser*> choices)
         : ElementParser(documentParser, logger)
+        , m_unknownNodeFlg(false)
+        , m_stockNode()
     {
         m_choices = choices;
     }
 
     bool DelayedChoiceElementParser::startElement(const NodeType::XMLNode& node, Attributes& attributes)
     {
-        ElementParser* choosenParser = nullptr;
-        for (ElementParser* parser : m_choices) {
-
-            if (choosenParser == nullptr && parser->handlesElement(node)) {
-                choosenParser = parser;
+        if (m_unknownNodeFlg) {
+            m_unknownNodeFlg = false;
+            m_documentParser.removeCurrentElementParser(this);
+            if (attributes.getAttribute("gml:id") == "") {
+                dynamic_cast <CityObjectElementParser*>(m_choices[2])->setAdeDataComingFlg(true);
+                m_choices[2]->startElement(m_stockNode, attributes);// for parent node
+                return m_choices[2]->startElement(node, attributes);
             } else {
-                delete parser;
+                if(m_choices[0]->handlesElement(node)){// check for GeometryElementParser
+                    m_documentParser.setCurrentElementParser(m_choices[0]); // set GeometryElementParser
+                    delete m_choices[1];
+                    dynamic_cast <GeometryElementParser*>(m_choices[0])->SetUnknownGeometryComingFlg(true);
+                    m_choices[0]->startElement(m_stockNode, attributes);
+                    return m_choices[0]->startElement(node, attributes);
+                } else {
+                    m_documentParser.setCurrentElementParser(m_choices[1]);// set CityObjectElementParser
+                    delete m_choices[0];
+                    dynamic_cast <CityObjectElementParser*>(m_choices[1])->SetUnknownCityObjectComingFlg(true);
+                    m_choices[1]->startElement(m_stockNode, attributes);
+                    return m_choices[1]->startElement(node, attributes);
+                }
+            }
+        } else {
+            ElementParser* choosenParser = nullptr;
+            for (ElementParser* parser : m_choices) {
+
+                if (choosenParser == nullptr && parser->handlesElement(node)) {
+                    choosenParser = parser;
+                } else {
+                    delete parser;
+                }
             }
 
-        }
-
-        if (choosenParser != nullptr) {
-            m_documentParser.removeCurrentElementParser(this);
-            m_documentParser.setCurrentElementParser(choosenParser);
-            return choosenParser->startElement(node, attributes);
-        } else {
-            CITYGML_LOG_ERROR(m_logger, "DelayedChoiceElementParser could not find a parser to handle <" << node << "> at " << getDocumentLocation());
-            throw std::runtime_error("No parser for XML element found.");
+            if (choosenParser != nullptr) {
+                m_documentParser.removeCurrentElementParser(this);
+                m_documentParser.setCurrentElementParser(choosenParser);
+                return choosenParser->startElement(node, attributes);
+            } else {
+                CITYGML_LOG_ERROR(m_logger, "DelayedChoiceElementParser could not find a parser to handle <" << node << "> at " << getDocumentLocation());
+                throw std::runtime_error("No parser for XML element found.");
+            }
         }
     }
 
-    bool DelayedChoiceElementParser::endElement(const NodeType::XMLNode&, const std::string&)
+    bool DelayedChoiceElementParser::endElement(const NodeType::XMLNode& node, const std::string& characters)
     {
-        throw std::runtime_error("DelayedChoiceElementParser::endElement must never be called.");
+        if (m_unknownNodeFlg) {// for unknown node which does not have any child
+            m_unknownNodeFlg = false;
+            m_documentParser.removeCurrentElementParser(this);
+            delete m_choices[0];
+            delete m_choices[1];
+            return dynamic_cast <CityObjectElementParser*>(m_choices[2])->parseChildElementBothTag(node, characters);
+        }else{
+            throw std::runtime_error("DelayedChoiceElementParser::endElement must never be called.");
+        }
     }
 
     bool DelayedChoiceElementParser::handlesElement(const NodeType::XMLNode& node) const
@@ -69,6 +104,14 @@ namespace citygml {
 
         ss << ")";
         return ss.str();
+    }
+
+    void DelayedChoiceElementParser::setUnknownNodeFlg(bool flg) {
+        m_unknownNodeFlg = flg;
+    }
+
+    void DelayedChoiceElementParser::setStockNode(const NodeType::XMLNode& node) {
+        m_stockNode = node;
     }
 
 }

--- a/sources/src/parser/geometryelementparser.cpp
+++ b/sources/src/parser/geometryelementparser.cpp
@@ -29,6 +29,7 @@ namespace citygml {
     GeometryElementParser::GeometryElementParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger,
                                                  int lodLevel, CityObject::CityObjectsType parentType,  std::function<void(Geometry*)> callback)
         : GMLObjectElementParser(documentParser, factory, logger)
+        , m_unknownGeometryCommingFlg(false)
     {
         m_callback = callback;
         m_lodLevel = lodLevel;
@@ -71,12 +72,14 @@ namespace citygml {
 
     bool GeometryElementParser::parseElementStartTag(const NodeType::XMLNode& node, Attributes& attributes)
     {
-
-        if (!handlesElement(node)) {
-            CITYGML_LOG_ERROR(m_logger, "Expected start tag of GeometryObject but got <" << node.name() << "> at " << getDocumentLocation());
-            throw std::runtime_error("Unexpected start tag found.");
+        if (m_unknownGeometryCommingFlg) {
+            m_unknownGeometryCommingFlg = false;
+        } else {
+            if (!handlesElement(node)) {
+                CITYGML_LOG_ERROR(m_logger, "Expected start tag of GeometryObject but got <" << node.name() << "> at " << getDocumentLocation());
+                throw std::runtime_error("Unexpected start tag found.");
+            }
         }
-
         std::string srsName = attributes.getAttribute("srsName");
 
         m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel, srsName);
@@ -171,4 +174,7 @@ namespace citygml {
         return m_model;
     }
 
+    void GeometryElementParser::SetUnknownGeometryComingFlg(bool flg) {
+        m_unknownGeometryCommingFlg = flg;
+    }
 }

--- a/sources/src/parser/geometryelementparser.cpp
+++ b/sources/src/parser/geometryelementparser.cpp
@@ -72,17 +72,19 @@ namespace citygml {
 
     bool GeometryElementParser::parseElementStartTag(const NodeType::XMLNode& node, Attributes& attributes)
     {
+        std::string srsName = attributes.getAttribute("srsName");
         if (m_unknownGeometryCommingFlg) {
+            m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel, srsName);
+            m_model->setAttribute(node.name(), attributes.getCityGMLIDAttribute());
             m_unknownGeometryCommingFlg = false;
         } else {
             if (!handlesElement(node)) {
                 CITYGML_LOG_ERROR(m_logger, "Expected start tag of GeometryObject but got <" << node.name() << "> at " << getDocumentLocation());
                 throw std::runtime_error("Unexpected start tag found.");
             }
+            m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel, srsName);
         }
-        std::string srsName = attributes.getAttribute("srsName");
 
-        m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel, srsName);
         m_orientation = attributes.getAttribute("orientation", "+"); // A gml:OrientableSurface may define a negative orientation
         return true;
 

--- a/sources/src/parser/geometryelementparser.cpp
+++ b/sources/src/parser/geometryelementparser.cpp
@@ -29,7 +29,6 @@ namespace citygml {
     GeometryElementParser::GeometryElementParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger,
                                                  int lodLevel, CityObject::CityObjectsType parentType,  std::function<void(Geometry*)> callback)
         : GMLObjectElementParser(documentParser, factory, logger)
-        , m_unknownGeometryCommingFlg(false)
     {
         m_callback = callback;
         m_lodLevel = lodLevel;
@@ -70,21 +69,16 @@ namespace citygml {
         return geometryTypeIDSet.count(node.typeID()) > 0;
     }
 
-    bool GeometryElementParser::parseElementStartTag(const NodeType::XMLNode& node, Attributes& attributes)
-    {
-        std::string srsName = attributes.getAttribute("srsName");
-        if (m_unknownGeometryCommingFlg) {
-            m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel, srsName);
-            m_model->setAttribute(node.name(), attributes.getCityGMLIDAttribute());
-            m_unknownGeometryCommingFlg = false;
-        } else {
-            if (!handlesElement(node)) {
-                CITYGML_LOG_ERROR(m_logger, "Expected start tag of GeometryObject but got <" << node.name() << "> at " << getDocumentLocation());
-                throw std::runtime_error("Unexpected start tag found.");
-            }
-            m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel, srsName);
+    bool GeometryElementParser::parseElementStartTag(const NodeType::XMLNode& node, Attributes& attributes) {
+
+        if (!handlesElement(node)) {
+            CITYGML_LOG_ERROR(m_logger, "Expected start tag of GeometryObject but got <" << node.name() << "> at " << getDocumentLocation());
+            throw std::runtime_error("Unexpected start tag found.");
         }
 
+        std::string srsName = attributes.getAttribute("srsName");
+
+        m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel, srsName);
         m_orientation = attributes.getAttribute("orientation", "+"); // A gml:OrientableSurface may define a negative orientation
         return true;
 
@@ -176,7 +170,4 @@ namespace citygml {
         return m_model;
     }
 
-    void GeometryElementParser::SetUnknownGeometryComingFlg(bool flg) {
-        m_unknownGeometryCommingFlg = flg;
-    }
 }

--- a/sources/src/parser/gmlobjectparser.cpp
+++ b/sources/src/parser/gmlobjectparser.cpp
@@ -32,7 +32,7 @@ namespace citygml {
         }
 
         if (node != NodeType::InvalidNode) return true;
-
+        
         size_t pos = node.name().find_first_of(":");
         if (pos != std::string::npos) {
             if (isupper(node.name().substr(pos + 1).at(0))) {// Ignore Tag start with capital letter

--- a/sources/src/parser/unknownelementparser.cpp
+++ b/sources/src/parser/unknownelementparser.cpp
@@ -22,11 +22,13 @@ namespace citygml {
     bool UnknownElementParser::startElement(const NodeType::XMLNode& node, Attributes& attributes)
     {
         m_documentParser.removeCurrentElementParser(this);
-        dynamic_cast <CityObjectElementParser*>(m_choices[2])->setAdeDataComingFlg(true);
-        m_choices[2]->startElement(m_stockNode, attributes);// for parent node
         if (attributes.getAttribute("gml:id") == "") {
+            dynamic_cast <CityObjectElementParser*>(m_choices[2])->setAdeDataComingFlg(true);
+            m_choices[2]->startElement(m_stockNode, attributes);// for parent node
             return m_choices[2]->startElement(node, attributes);
         } else {
+            dynamic_cast <CityObjectElementParser*>(m_choices[2])->setSkippedTag(m_stockNode.name());
+
             if(m_choices[0]->handlesElement(node)){// check for GeometryElementParser
                 delete m_choices[1];
                 setParserForNextElement(m_choices[0]);

--- a/sources/src/parser/unknownelementparser.cpp
+++ b/sources/src/parser/unknownelementparser.cpp
@@ -1,0 +1,85 @@
+#include "parser/unknownelementparser.h"
+#include "parser/geometryelementparser.h"
+#include "parser/documentlocation.h"
+#include "parser/citygmldocumentparser.h"
+#include "parser/attributes.h"
+#include "parser/cityobjectelementparser.h"
+
+#include <citygml/citygmllogger.h>
+
+#include <sstream>
+#include <stdexcept>
+
+namespace citygml {
+
+    UnknownElementParser::UnknownElementParser(CityGMLDocumentParser& documentParser, std::shared_ptr<CityGMLLogger> logger, std::vector<ElementParser*> choices)
+        : ElementParser(documentParser, logger)
+        , m_stockNode()
+    {
+        m_choices = choices;
+    }
+
+    bool UnknownElementParser::startElement(const NodeType::XMLNode& node, Attributes& attributes)
+    {
+        m_documentParser.removeCurrentElementParser(this);
+        if (attributes.getAttribute("gml:id") == "") {
+            dynamic_cast <CityObjectElementParser*>(m_choices[2])->setAdeDataComingFlg(true);
+            m_choices[2]->startElement(m_stockNode, attributes);// for parent node
+            return m_choices[2]->startElement(node, attributes);
+        } else {
+            if(m_choices[0]->handlesElement(node)){// check for GeometryElementParser
+                m_documentParser.setCurrentElementParser(m_choices[0]); // set GeometryElementParser
+                delete m_choices[1];
+                dynamic_cast <GeometryElementParser*>(m_choices[0])->SetUnknownGeometryComingFlg(true);
+                m_choices[0]->startElement(m_stockNode, attributes);
+                return m_choices[0]->startElement(node, attributes);
+            } else {
+                m_documentParser.setCurrentElementParser(m_choices[1]);// set CityObjectElementParser
+                delete m_choices[0];
+                dynamic_cast <CityObjectElementParser*>(m_choices[1])->SetUnknownCityObjectComingFlg(true);
+                m_choices[1]->startElement(m_stockNode, attributes);
+                return m_choices[1]->startElement(node, attributes);
+            }
+        }
+    }
+
+    bool UnknownElementParser::endElement(const NodeType::XMLNode& node, const std::string& characters)
+    {
+        m_documentParser.removeCurrentElementParser(this);
+        delete m_choices[0];
+        delete m_choices[1];
+        return dynamic_cast <CityObjectElementParser*>(m_choices[2])->parseChildElementBothTag(node, characters);   
+    }
+
+    bool UnknownElementParser::handlesElement(const NodeType::XMLNode& node) const
+    {
+        for (const ElementParser* parser : m_choices) {
+            if (parser->handlesElement(node)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::string UnknownElementParser::elementParserName() const
+    {
+        std::stringstream ss;
+        ss << "UnknownElementParser (";
+        for (size_t i = 0; i < m_choices.size(); i++) {
+
+            if (i > 0) {
+                ss << " | ";
+            }
+
+            ss << m_choices[i]->elementParserName();
+        }
+
+        ss << ")";
+        return ss.str();
+    }
+
+    void UnknownElementParser::setStockNode(const NodeType::XMLNode& node) {
+        m_stockNode = node;
+    }
+
+}

--- a/sources/src/parser/unknownelementparser.cpp
+++ b/sources/src/parser/unknownelementparser.cpp
@@ -22,22 +22,18 @@ namespace citygml {
     bool UnknownElementParser::startElement(const NodeType::XMLNode& node, Attributes& attributes)
     {
         m_documentParser.removeCurrentElementParser(this);
+        dynamic_cast <CityObjectElementParser*>(m_choices[2])->setAdeDataComingFlg(true);
+        m_choices[2]->startElement(m_stockNode, attributes);// for parent node
         if (attributes.getAttribute("gml:id") == "") {
-            dynamic_cast <CityObjectElementParser*>(m_choices[2])->setAdeDataComingFlg(true);
-            m_choices[2]->startElement(m_stockNode, attributes);// for parent node
             return m_choices[2]->startElement(node, attributes);
         } else {
             if(m_choices[0]->handlesElement(node)){// check for GeometryElementParser
-                m_documentParser.setCurrentElementParser(m_choices[0]); // set GeometryElementParser
                 delete m_choices[1];
-                dynamic_cast <GeometryElementParser*>(m_choices[0])->SetUnknownGeometryComingFlg(true);
-                m_choices[0]->startElement(m_stockNode, attributes);
+                setParserForNextElement(m_choices[0]);
                 return m_choices[0]->startElement(node, attributes);
             } else {
-                m_documentParser.setCurrentElementParser(m_choices[1]);// set CityObjectElementParser
                 delete m_choices[0];
-                dynamic_cast <CityObjectElementParser*>(m_choices[1])->SetUnknownCityObjectComingFlg(true);
-                m_choices[1]->startElement(m_stockNode, attributes);
+                setParserForNextElement(m_choices[1]);
                 return m_choices[1]->startElement(node, attributes);
             }
         }
@@ -46,8 +42,6 @@ namespace citygml {
     bool UnknownElementParser::endElement(const NodeType::XMLNode& node, const std::string& characters)
     {
         m_documentParser.removeCurrentElementParser(this);
-        delete m_choices[0];
-        delete m_choices[1];
         return dynamic_cast <CityObjectElementParser*>(m_choices[2])->parseChildElementBothTag(node, characters);   
     }
 


### PR DESCRIPTION
ADEによる拡張属性の対応(ジオメトリ・地物)

- 一つ下のタグ(型名)がIDを持たないなら無視する(データ型としてパースする)
- IDを持つ場合、タグの型名からGeometryかCityObjectか判別してパースする
- LODは一律2にする
