### PR TITLE
fix bug of CityModel::GetAllCityObjectsOfType 

### DIFF
--- a/sources/src/citygml/citymodel.cpp
+++ b/sources/src/citygml/citymodel.cpp
@@ -94,9 +94,6 @@ namespace citygml
         if (keys.empty())
             return {};
 
-        if (keys.size() == 1)
-            return m_cityObjectsMap.find(type)->second;
-
         ConstCityObjects result;
         for (const auto& key : keys) {
             const auto city_objects = m_cityObjectsMap.find(key)->second;

--- a/sources/src/citygml/citymodel.cpp
+++ b/sources/src/citygml/citymodel.cpp
@@ -94,6 +94,10 @@ namespace citygml
         if (keys.empty())
             return {};
 
+        if(keys.size() == 1){
+            return m_cityObjectsMap.find(keys[0])->second;
+        }
+
         ConstCityObjects result;
         for (const auto& key : keys) {
             const auto city_objects = m_cityObjectsMap.find(key)->second;


### PR DESCRIPTION
GetAllCityObjectsOfType が、次のケースで例外を出すバグを修正しました :  
CityModel内に存在する地物タイプが1種類であり、かつ引数に複数のタイプを含むタイプフラグを渡すとき  